### PR TITLE
Update cargo install for afl. Fixes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ As a part of the [Substrate Builders Program](https://substrate.io/ecosystem/sub
 Here are the steps to launch `substrate-runtime-fuzzer` against the [node template runtime](https://github.com/paritytech/substrate/tree/master/bin/node-template/runtime):
 
 ```
-cargo install ziggy afl honggfuzz grcov
+cargo install ziggy cargo-afl honggfuzz grcov
 rustup target add wasm32-unknown-unknown
 git clone https://github.com/srlabs/substrate-runtime-fuzzer
 cd substrate-runtime-fuzzer/node-template-fuzzer/


### PR DESCRIPTION
we need to install the afl binary, not only the library.