### PR TITLE
Use basic externalities

### DIFF
--- a/kitchensink-fuzzer/Cargo.toml
+++ b/kitchensink-fuzzer/Cargo.toml
@@ -34,6 +34,8 @@ pallet-society = { git = "https://github.com/paritytech/polkadot-sdk.git", tag =
 pallet-lottery = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.1.0", default-features = false }
 pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.1.0", default-features = false }
 pallet-multisig = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.1.0", default-features = false }
+pallet-remark = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.1.0", default-features = false }
+pallet-transaction-storage = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-v1.1.0", default-features = false }
 
 [features]
 default = ["std", "try-runtime"]

--- a/kitchensink-fuzzer/src/main.rs
+++ b/kitchensink-fuzzer/src/main.rs
@@ -23,7 +23,8 @@ use std::time::{Duration, Instant};
 
 /// Types from the fuzzed runtime.
 type Balance = <Runtime as pallet_balances::Config>::Balance;
-type Externalities = sp_state_machine::TestExternalities<sp_core::Blake2Hasher>;
+// We use a simple Map-based Externalities implementation
+type Externalities = sp_state_machine::BasicExternalities;
 
 // The initial timestamp at the start of an input run.
 const INITIAL_TIMESTAMP: u64 = 0;

--- a/kitchensink-fuzzer/src/main.rs
+++ b/kitchensink-fuzzer/src/main.rs
@@ -411,6 +411,17 @@ fn main() {
                 continue;
             }
 
+            // We filter out store extrinsics because BasicExternalities does not support them.
+            if recursively_find_call(extrinsic.clone(), |call| {
+                matches!(
+                    call,
+                    RuntimeCall::TransactionStorage(pallet_transaction_storage::Call::store { .. })
+                        | RuntimeCall::Remark(pallet_remark::Call::store { .. })
+                )
+            }) {
+                continue;
+            }
+
             // If the lapse is in the range [0, MAX_BLOCK_LAPSE] we finalize the block and initialize
             // a new one.
             if lapse > 0 && lapse < MAX_BLOCK_LAPSE {

--- a/kusama-fuzzer/src/main.rs
+++ b/kusama-fuzzer/src/main.rs
@@ -20,8 +20,8 @@ use staging_kusama_runtime::{
 };
 use std::time::{Duration, Instant};
 
-/// Types from the fuzzed runtime.
-type Externalities = sp_state_machine::TestExternalities<sp_core::Blake2Hasher>;
+// We use a simple Map-based Externalities implementation
+type Externalities = sp_state_machine::BasicExternalities;
 
 // The initial timestamp at the start of an input run.
 const INITIAL_TIMESTAMP: u64 = 0;

--- a/node-template-fuzzer/src/main.rs
+++ b/node-template-fuzzer/src/main.rs
@@ -16,7 +16,8 @@ use sp_runtime::{
 };
 use std::time::{Duration, Instant};
 
-type Externalities = sp_state_machine::TestExternalities<sp_core::Blake2Hasher>;
+// We use a simple Map-based Externalities implementation
+type Externalities = sp_state_machine::BasicExternalities;
 
 // The initial timestamp at the start of an input run.
 const INITIAL_TIMESTAMP: u64 = 0;

--- a/statemine-fuzzer/src/main.rs
+++ b/statemine-fuzzer/src/main.rs
@@ -16,10 +16,8 @@ use sp_runtime::{
 };
 use std::time::{Duration, Instant};
 
-// type RuntimeHelper = parachains_runtimes_test_utils::RuntimeHelper<Runtime, AllPalletsWithoutSystem>;
-
-/// Types from the fuzzed runtime.
-type Externalities = sp_state_machine::TestExternalities<sp_core::Blake2Hasher>;
+// We use a simple Map-based Externalities implementation
+type Externalities = sp_state_machine::BasicExternalities;
 
 // The initial timestamp at the start of an input run.
 const INITIAL_TIMESTAMP: u64 = 0;


### PR DESCRIPTION
~30% speedup because we're not hashing as many storage items.