### PR TITLE
CI and fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,5 @@ jobs:
           rustup target add wasm32-unknown-unknown
       - name: Build fuzzer
         run: |
-          cargo afl config --build --firce
+          cargo afl config --build --force
           cargo ziggy build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,5 @@ jobs:
           rustup target add wasm32-unknown-unknown
       - name: Build fuzzer
         run: |
-          cargo afl config --build
-          cargo ziggy build
-          cargo afl config --build --force
+          cargo afl config --build --firce
           cargo ziggy build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-node-template-fuzzers:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup dependencies
+      run: >
+        cargo install ziggy cargo-afl honggfuzz grcov
+        rustup target add wasm32-unknown-unknown
+    - name: Build fuzzer
+      run: cargo ziggy build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,9 @@ jobs:
         run: |
           cargo install ziggy cargo-afl honggfuzz grcov
           rustup target add wasm32-unknown-unknown
-          cargo afl config --build
       - name: Build fuzzer
-        run: cargo ziggy build
+        run: |
+          cargo afl config --build
+          cargo ziggy build
+          cargo afl config --build --force
+          cargo ziggy build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Setup dependencies
       run: >
-        cargo install ziggy cargo-afl honggfuzz grcov
+        cargo install ziggy cargo-afl honggfuzz grcov \
         rustup target add wasm32-unknown-unknown
     - name: Build fuzzer
       run: cargo ziggy build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Setup dependencies
-      run: >
-        cargo install ziggy cargo-afl honggfuzz grcov \
+      run: |
+        cargo install ziggy cargo-afl honggfuzz grcov
         rustup target add wasm32-unknown-unknown
     - name: Build fuzzer
       run: cargo ziggy build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,23 +2,23 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
   build-node-template-fuzzers:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup dependencies
-      run: |
-        cargo install ziggy cargo-afl honggfuzz grcov
-        rustup target add wasm32-unknown-unknown
-    - name: Build fuzzer
-      run: cargo ziggy build
+      - uses: actions/checkout@v3
+      - name: Setup dependencies
+        run: |
+          cargo install ziggy cargo-afl honggfuzz grcov
+          rustup target add wasm32-unknown-unknown
+          cargo afl config --build
+      - name: Build fuzzer
+        run: cargo ziggy build

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly"
+channel = "nightly-2024-02-04"
 components = [ "rustfmt", "rustc-dev" ]
 targets = [ "wasm32-unknown-unknown", "thumbv2-none-eabi" ]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly"
+components = [ "rustfmt", "rustc-dev" ]
+targets = [ "wasm32-unknown-unknown", "thumbv2-none-eabi" ]
+profile = "minimal"


### PR DESCRIPTION
The stdsimd unstable feature was removed from rust, some packages updated with that in mind. Many are broken.

https://github.com/rust-lang/rust/issues/48556

I am adding a CI to catch issues in the future, as well as a rust-toolchain.toml file to lock the toolchain to a good version in the future.

With the current toolchain setup, all thats left for everything to get back into working order is for Ahash to accept a patch for an older version that is still used by some dependencies of this project.

https://github.com/tkaitchuck/aHash/pull/201