### PR TITLE
Kitchensink stable2512 2

### DIFF
--- a/templates/Cargo.lock
+++ b/templates/Cargo.lock
@@ -1152,7 +1152,7 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 [[package]]
 name = "asset-test-utils"
 version = "29.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "assets-common",
  "cumulus-pallet-parachain-system",
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "assets-common"
 version = "0.27.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "ethereum-standards",
@@ -1489,7 +1489,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "binary-merkle-tree"
 version = "16.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "hash-db",
  "log",
@@ -1759,7 +1759,7 @@ dependencies = [
 [[package]]
 name = "bp-header-chain"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-runtime",
  "finality-grandpa",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "bp-messages"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -1792,7 +1792,7 @@ dependencies = [
 [[package]]
 name = "bp-parachains"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-header-chain",
  "bp-polkadot-core",
@@ -1809,7 +1809,7 @@ dependencies = [
 [[package]]
 name = "bp-polkadot-core"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1826,7 +1826,7 @@ dependencies = [
 [[package]]
 name = "bp-relayers"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "bp-runtime"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -1867,7 +1867,7 @@ dependencies = [
 [[package]]
 name = "bp-test-utils"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub"
 version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -1904,7 +1904,7 @@ dependencies = [
 [[package]]
 name = "bp-xcm-bridge-hub-router"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1916,7 +1916,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-common"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -1935,7 +1935,7 @@ dependencies = [
 [[package]]
 name = "bridge-hub-test-utils"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "asset-test-utils",
  "bp-header-chain",
@@ -1977,7 +1977,7 @@ dependencies = [
 [[package]]
 name = "bridge-runtime-common"
 version = "0.26.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -2883,7 +2883,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-bootnodes"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -2907,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-cli"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -2924,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-collator"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -2947,7 +2947,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-aura"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -2995,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-common"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -3027,7 +3027,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-proposer"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3047,7 +3047,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -3070,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-network"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -3098,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-parachain-inherent"
 version = "0.22.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3109,7 +3109,7 @@ dependencies = [
  "sc-client-api",
  "sc-consensus-babe",
  "sc-network-types",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -3120,7 +3120,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-pov-recovery"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3148,7 +3148,7 @@ dependencies = [
 [[package]]
 name = "cumulus-client-service"
 version = "0.31.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-channel 1.9.0",
  "cumulus-client-cli",
@@ -3191,7 +3191,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-aura-ext"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3208,7 +3208,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-dmp-queue"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -3225,7 +3225,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-parachain-system-proc-macro"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -3274,7 +3274,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-session-benchmarking"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-solo-to-para"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -3302,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-weight-reclaim"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-storage-weight-reclaim",
  "derive-where",
@@ -3321,7 +3321,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcm"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3336,7 +3336,7 @@ dependencies = [
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "approx",
  "bounded-collections 0.3.2",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "cumulus-ping"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-primitives-core",
@@ -3377,7 +3377,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-aura"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "sp-api",
  "sp-consensus-aura",
@@ -3386,7 +3386,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-core"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -3403,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-storage-weight-reclaim"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-proof-size-hostfunction",
@@ -3444,7 +3444,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-timestamp"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "sp-inherents",
@@ -3454,7 +3454,7 @@ dependencies = [
 [[package]]
 name = "cumulus-primitives-utility"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -3471,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
 version = "0.31.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -3499,7 +3499,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-interface"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
 version = "0.31.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -3555,7 +3555,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
 version = "0.28.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -3588,7 +3588,7 @@ dependencies = [
 [[package]]
 name = "cumulus-relay-chain-streams"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-relay-chain-interface",
  "futures",
@@ -3602,7 +3602,7 @@ dependencies = [
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
 version = "0.24.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -4391,7 +4391,7 @@ dependencies = [
 [[package]]
 name = "ethereum-standards"
 version = "0.1.2"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "alloy-core",
 ]
@@ -4635,7 +4635,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 [[package]]
 name = "fork-tree"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -4667,8 +4667,8 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frame-benchmarking"
-version = "45.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "45.0.3"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -4692,7 +4692,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "53.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -4757,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-pallet-pov"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4785,7 +4785,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-solution-type"
 version = "16.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -4796,7 +4796,7 @@ dependencies = [
 [[package]]
 name = "frame-election-provider-support"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -4813,7 +4813,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "45.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "const-hex",
@@ -4859,7 +4859,7 @@ dependencies = [
 [[package]]
 name = "frame-storage-access-test-runtime"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "parity-scale-codec",
@@ -4873,7 +4873,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "45.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -4914,7 +4914,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "36.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -4927,14 +4927,14 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "syn 2.0.114",
 ]
 
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.4.0",
@@ -4946,7 +4946,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4956,7 +4956,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cfg-if",
  "docify",
@@ -4975,7 +4975,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -4989,7 +4989,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -4999,7 +4999,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -6542,7 +6542,7 @@ dependencies = [
 [[package]]
 name = "kitchensink-runtime"
 version = "3.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "log",
@@ -7524,7 +7524,7 @@ dependencies = [
 [[package]]
 name = "mmr-gadget"
 version = "50.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "log",
@@ -7543,7 +7543,7 @@ dependencies = [
 [[package]]
 name = "mmr-rpc"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -7851,7 +7851,7 @@ checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 [[package]]
 name = "node-primitives"
 version = "2.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -8192,7 +8192,7 @@ dependencies = [
 [[package]]
 name = "pallet-alliance"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8203,7 +8203,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-io",
  "sp-runtime",
 ]
@@ -8211,7 +8211,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8229,7 +8229,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-ops"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8247,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-conversion-tx-payment"
 version = "27.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8262,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rate"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8276,7 +8276,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-rewards"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8294,7 +8294,7 @@ dependencies = [
 [[package]]
 name = "pallet-asset-tx-payment"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets"
 version = "48.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-freezer"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "pallet-assets",
@@ -8338,7 +8338,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-holder"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8353,7 +8353,7 @@ dependencies = [
 [[package]]
 name = "pallet-assets-precompiles"
 version = "0.4.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "ethereum-standards",
  "frame-support",
@@ -8364,7 +8364,7 @@ dependencies = [
 [[package]]
 name = "pallet-atomic-swap"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -8374,7 +8374,7 @@ dependencies = [
 [[package]]
 name = "pallet-aura"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8390,7 +8390,7 @@ dependencies = [
 [[package]]
 name = "pallet-authority-discovery"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8405,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8418,7 +8418,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8440,8 +8440,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-bags-list"
-version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "44.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "aquamarine",
  "docify",
@@ -8462,7 +8462,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8478,7 +8478,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8497,7 +8497,7 @@ dependencies = [
 [[package]]
 name = "pallet-beefy-mmr"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "binary-merkle-tree",
@@ -8522,7 +8522,7 @@ dependencies = [
 [[package]]
 name = "pallet-bounties"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8539,7 +8539,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-grandpa"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-header-chain",
  "bp-runtime",
@@ -8558,7 +8558,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-messages"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -8577,7 +8577,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-parachains"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-header-chain",
  "bp-parachains",
@@ -8597,7 +8597,7 @@ dependencies = [
 [[package]]
 name = "pallet-bridge-relayers"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-header-chain",
  "bp-messages",
@@ -8620,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "pallet-broker"
 version = "0.24.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8638,7 +8638,7 @@ dependencies = [
 [[package]]
 name = "pallet-child-bounties"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8656,7 +8656,7 @@ dependencies = [
 [[package]]
 name = "pallet-collator-selection"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8675,7 +8675,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -8692,7 +8692,7 @@ dependencies = [
 [[package]]
 name = "pallet-collective-content"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8706,7 +8706,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts"
 version = "45.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -8736,7 +8736,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-mock-network"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8767,7 +8767,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-proc-macro"
 version = "23.0.3"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8777,7 +8777,7 @@ dependencies = [
 [[package]]
 name = "pallet-contracts-uapi"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -8788,7 +8788,7 @@ dependencies = [
 [[package]]
 name = "pallet-conviction-voting"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -8804,7 +8804,7 @@ dependencies = [
 [[package]]
 name = "pallet-core-fellowship"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8821,8 +8821,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-dap"
-version = "0.1.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "0.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8836,7 +8836,7 @@ dependencies = [
 [[package]]
 name = "pallet-delegated-staking"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8851,7 +8851,7 @@ dependencies = [
 [[package]]
 name = "pallet-democracy"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8868,7 +8868,7 @@ dependencies = [
 [[package]]
 name = "pallet-derivatives"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8888,7 +8888,7 @@ dependencies = [
 [[package]]
 name = "pallet-dev-mode"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -8903,7 +8903,7 @@ dependencies = [
 [[package]]
 name = "pallet-dummy-dim"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8921,7 +8921,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-block"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8942,7 +8942,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-multi-phase"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8963,7 +8963,7 @@ dependencies = [
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -8976,7 +8976,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -8994,7 +8994,7 @@ dependencies = [
 [[package]]
 name = "pallet-example-mbm"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9009,7 +9009,7 @@ dependencies = [
 [[package]]
 name = "pallet-example-tasks"
 version = "1.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9025,7 +9025,7 @@ dependencies = [
 [[package]]
 name = "pallet-fast-unstake"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9043,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "pallet-glutton"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "blake2 0.10.6",
  "frame-benchmarking",
@@ -9061,7 +9061,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9083,7 +9083,7 @@ dependencies = [
 [[package]]
 name = "pallet-identity"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9099,7 +9099,7 @@ dependencies = [
 [[package]]
 name = "pallet-im-online"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9118,7 +9118,7 @@ dependencies = [
 [[package]]
 name = "pallet-indices"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9133,7 +9133,7 @@ dependencies = [
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
 version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9144,7 +9144,7 @@ dependencies = [
 [[package]]
 name = "pallet-lottery"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9157,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "pallet-membership"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9173,7 +9173,7 @@ dependencies = [
 [[package]]
 name = "pallet-message-queue"
 version = "48.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -9192,7 +9192,7 @@ dependencies = [
 [[package]]
 name = "pallet-meta-tx"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9210,7 +9210,7 @@ dependencies = [
 [[package]]
 name = "pallet-migrations"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9229,7 +9229,7 @@ dependencies = [
 [[package]]
 name = "pallet-mixnet"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9243,7 +9243,7 @@ dependencies = [
 [[package]]
 name = "pallet-mmr"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9255,7 +9255,7 @@ dependencies = [
 [[package]]
 name = "pallet-multi-asset-bounties"
 version = "0.2.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9272,7 +9272,7 @@ dependencies = [
 [[package]]
 name = "pallet-multisig"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9283,7 +9283,7 @@ dependencies = [
 [[package]]
 name = "pallet-nft-fractionalization"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "pallet-assets",
@@ -9296,7 +9296,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -9313,7 +9313,7 @@ dependencies = [
 [[package]]
 name = "pallet-nfts-runtime-api"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9322,7 +9322,7 @@ dependencies = [
 [[package]]
 name = "pallet-nis"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9332,7 +9332,7 @@ dependencies = [
 [[package]]
 name = "pallet-node-authorization"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -9342,8 +9342,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "43.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "43.0.2"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9361,7 +9361,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9381,7 +9381,7 @@ dependencies = [
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
 version = "41.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -9391,7 +9391,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9406,7 +9406,7 @@ dependencies = [
 [[package]]
 name = "pallet-offences-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9429,7 +9429,7 @@ dependencies = [
 [[package]]
 name = "pallet-oracle"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9447,7 +9447,7 @@ dependencies = [
 [[package]]
 name = "pallet-oracle-runtime-api"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9458,7 +9458,7 @@ dependencies = [
 [[package]]
 name = "pallet-origin-restriction"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9476,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "pallet-paged-list"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -9488,7 +9488,7 @@ dependencies = [
 [[package]]
 name = "pallet-parameters"
 version = "0.16.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9505,7 +9505,7 @@ dependencies = [
 [[package]]
 name = "pallet-people"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9523,7 +9523,7 @@ dependencies = [
 [[package]]
 name = "pallet-preimage"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9539,7 +9539,7 @@ dependencies = [
 [[package]]
 name = "pallet-proxy"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9549,7 +9549,7 @@ dependencies = [
 [[package]]
 name = "pallet-ranked-collective"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9567,7 +9567,7 @@ dependencies = [
 [[package]]
 name = "pallet-recovery"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -9577,7 +9577,7 @@ dependencies = [
 [[package]]
 name = "pallet-referenda"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9594,7 +9594,7 @@ dependencies = [
 [[package]]
 name = "pallet-remark"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9610,7 +9610,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive"
 version = "0.12.2"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "alloy-consensus",
  "alloy-core",
@@ -9661,7 +9661,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-fixtures"
 version = "0.9.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "alloy-core",
  "anyhow",
@@ -9678,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-proc-macro"
 version = "0.7.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9688,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "pallet-revive-uapi"
 version = "0.10.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "alloy-core",
  "bitflags 1.3.2",
@@ -9703,7 +9703,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-offences"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9719,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "pallet-root-testing"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9732,7 +9732,7 @@ dependencies = [
 [[package]]
 name = "pallet-safe-mode"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "pallet-balances",
@@ -9746,7 +9746,7 @@ dependencies = [
 [[package]]
 name = "pallet-salary"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "pallet-ranked-collective",
@@ -9758,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "pallet-scheduler"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -9775,7 +9775,7 @@ dependencies = [
 [[package]]
 name = "pallet-scored-pool"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9787,8 +9787,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "45.1.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9810,7 +9810,7 @@ dependencies = [
 [[package]]
 name = "pallet-session-benchmarking"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9826,7 +9826,7 @@ dependencies = [
 [[package]]
 name = "pallet-skip-feeless-payment"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -9838,7 +9838,7 @@ dependencies = [
 [[package]]
 name = "pallet-society"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9855,7 +9855,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9875,8 +9875,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-async"
-version = "0.9.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "0.10.1"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -9900,8 +9900,8 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-async-ah-client"
-version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "0.7.2"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -9920,9 +9920,10 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-async-rc-client"
-version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "0.7.1"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "impl-trait-for-tuples",
@@ -9933,12 +9934,14 @@ dependencies = [
  "sp-runtime",
  "sp-staking",
  "staging-xcm",
+ "staging-xcm-builder",
+ "staging-xcm-executor",
 ]
 
 [[package]]
 name = "pallet-staking-async-reward-fn"
 version = "0.3.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9947,7 +9950,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-async-runtime-api"
 version = "0.5.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9957,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-curve"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -9968,7 +9971,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-reward-fn"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -9977,7 +9980,7 @@ dependencies = [
 [[package]]
 name = "pallet-staking-runtime-api"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -9987,7 +9990,7 @@ dependencies = [
 [[package]]
 name = "pallet-state-trie-migration"
 version = "50.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10003,7 +10006,7 @@ dependencies = [
 [[package]]
 name = "pallet-statement"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10020,7 +10023,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10035,7 +10038,7 @@ dependencies = [
 [[package]]
 name = "pallet-template"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10047,7 +10050,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10065,7 +10068,7 @@ dependencies = [
 [[package]]
 name = "pallet-tips"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10083,7 +10086,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10099,7 +10102,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "48.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -10115,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -10127,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-storage"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10146,7 +10149,7 @@ dependencies = [
 [[package]]
 name = "pallet-treasury"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -10165,7 +10168,7 @@ dependencies = [
 [[package]]
 name = "pallet-tx-pause"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -10176,7 +10179,7 @@ dependencies = [
 [[package]]
 name = "pallet-uniques"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10190,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "pallet-utility"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10205,7 +10208,7 @@ dependencies = [
 [[package]]
 name = "pallet-verify-signature"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10220,7 +10223,7 @@ dependencies = [
 [[package]]
 name = "pallet-vesting"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10234,7 +10237,7 @@ dependencies = [
 [[package]]
 name = "pallet-whitelist"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-sdk-frame",
@@ -10244,7 +10247,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bounded-collections 0.3.2",
  "frame-benchmarking",
@@ -10268,7 +10271,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-benchmarks"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -10285,7 +10288,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-messages",
  "bp-runtime",
@@ -10307,7 +10310,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-bridge-hub-router"
 version = "0.23.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-xcm-bridge-hub-router",
  "frame-benchmarking",
@@ -10327,7 +10330,7 @@ dependencies = [
 [[package]]
 name = "pallet-xcm-precompiles"
 version = "0.3.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "pallet-revive",
@@ -10341,7 +10344,7 @@ dependencies = [
 [[package]]
 name = "parachains-common"
 version = "27.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
@@ -10373,7 +10376,7 @@ dependencies = [
 [[package]]
 name = "parachains-runtimes-test-utils"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "cumulus-pallet-xcmp-queue",
@@ -10754,7 +10757,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "polkadot-approval-distribution"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10772,7 +10775,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10787,7 +10790,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-distribution"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "fatality",
  "futures",
@@ -10810,7 +10813,7 @@ dependencies = [
 [[package]]
 name = "polkadot-availability-recovery"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "fatality",
@@ -10843,7 +10846,7 @@ dependencies = [
 [[package]]
 name = "polkadot-cli"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "clap",
  "frame-benchmarking-cli",
@@ -10868,7 +10871,7 @@ dependencies = [
 [[package]]
 name = "polkadot-collator-protocol"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitvec",
  "fatality",
@@ -10891,7 +10894,7 @@ dependencies = [
 [[package]]
 name = "polkadot-core-primitives"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10902,7 +10905,7 @@ dependencies = [
 [[package]]
 name = "polkadot-dispute-distribution"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "fatality",
  "futures",
@@ -10924,7 +10927,7 @@ dependencies = [
 [[package]]
 name = "polkadot-erasure-coding"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -10938,7 +10941,7 @@ dependencies = [
 [[package]]
 name = "polkadot-gossip-support"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -10951,7 +10954,7 @@ dependencies = [
  "sc-network",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-keystore",
  "tracing-gum",
 ]
@@ -10959,7 +10962,7 @@ dependencies = [
 [[package]]
 name = "polkadot-network-bridge"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -10982,7 +10985,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-collation-generation"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -11000,7 +11003,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -11032,7 +11035,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-approval-voting-parallel"
 version = "0.11.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -11056,7 +11059,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-av-store"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitvec",
  "futures",
@@ -11075,7 +11078,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-backing"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11096,7 +11099,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -11111,7 +11114,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-candidate-validation"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -11133,7 +11136,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -11147,7 +11150,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-chain-selection"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "futures-timer",
@@ -11163,7 +11166,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "fatality",
  "futures",
@@ -11181,7 +11184,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -11198,7 +11201,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "fatality",
  "futures",
@@ -11212,7 +11215,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-provisioner"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitvec",
  "fatality",
@@ -11231,7 +11234,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "always-assert",
  "array-bytes",
@@ -11259,7 +11262,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-checker"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "polkadot-node-subsystem",
@@ -11272,7 +11275,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-pvf-common"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cpu-time",
  "futures",
@@ -11288,7 +11291,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -11299,7 +11302,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-core-runtime-api"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "polkadot-node-metrics",
@@ -11314,7 +11317,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-metrics"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bs58",
  "futures",
@@ -11331,7 +11334,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-network-protocol"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-channel 1.9.0",
  "async-trait",
@@ -11356,7 +11359,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-primitives"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -11380,7 +11383,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "polkadot-node-subsystem-types",
  "polkadot-overseer",
@@ -11389,7 +11392,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-types"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "derive_more 0.99.20",
@@ -11417,7 +11420,7 @@ dependencies = [
 [[package]]
 name = "polkadot-node-subsystem-util"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "fatality",
  "futures",
@@ -11447,7 +11450,7 @@ dependencies = [
 [[package]]
 name = "polkadot-omni-node-lib"
 version = "0.13.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "clap",
@@ -11534,7 +11537,7 @@ dependencies = [
 [[package]]
 name = "polkadot-overseer"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -11554,7 +11557,7 @@ dependencies = [
 [[package]]
 name = "polkadot-parachain-primitives"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "bounded-collections 0.3.2",
@@ -11571,7 +11574,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitvec",
  "bounded-collections 0.3.2",
@@ -11600,7 +11603,7 @@ dependencies = [
 [[package]]
 name = "polkadot-primitives-test-helpers"
 version = "0.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -11615,7 +11618,7 @@ dependencies = [
 [[package]]
 name = "polkadot-rpc"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -11648,7 +11651,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-common"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -11698,7 +11701,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-metrics"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bs58",
  "frame-benchmarking",
@@ -11710,7 +11713,7 @@ dependencies = [
 [[package]]
 name = "polkadot-runtime-parachains"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -11756,8 +11759,8 @@ dependencies = [
 
 [[package]]
 name = "polkadot-sdk"
-version = "2512.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "2512.3.3"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "asset-test-utils",
  "assets-common",
@@ -11963,7 +11966,7 @@ dependencies = [
  "sp-core",
  "sp-core-hashing",
  "sp-crypto-ec-utils",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
  "sp-externalities",
@@ -12009,7 +12012,7 @@ dependencies = [
 [[package]]
 name = "polkadot-sdk-frame"
 version = "0.14.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -12044,7 +12047,7 @@ dependencies = [
 [[package]]
 name = "polkadot-service"
 version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -12152,7 +12155,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-distribution"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitvec",
  "fatality",
@@ -12172,7 +12175,7 @@ dependencies = [
 [[package]]
 name = "polkadot-statement-table"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
@@ -13391,7 +13394,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime"
 version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -13489,7 +13492,7 @@ dependencies = [
 [[package]]
 name = "rococo-runtime-constants"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -13838,7 +13841,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "35.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "sp-core",
@@ -13849,7 +13852,7 @@ dependencies = [
 [[package]]
 name = "sc-authority-discovery"
 version = "0.55.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -13881,7 +13884,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.53.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "log",
@@ -13903,7 +13906,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.48.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -13918,7 +13921,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "48.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "clap",
@@ -13934,7 +13937,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -13945,7 +13948,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -13956,7 +13959,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.57.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "bip39",
@@ -13998,7 +14001,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "fnv",
  "futures",
@@ -14024,7 +14027,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.51.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -14052,7 +14055,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.54.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -14075,7 +14078,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.55.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14106,7 +14109,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe"
 version = "0.55.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -14131,7 +14134,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -14143,7 +14146,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-babe-rpc"
 version = "0.55.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14165,7 +14168,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14199,7 +14202,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-beefy-rpc"
 version = "34.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14219,7 +14222,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-epochs"
 version = "0.54.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -14232,7 +14235,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "ahash 0.8.12",
  "array-bytes",
@@ -14266,7 +14269,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -14276,7 +14279,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -14296,7 +14299,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-manual-seal"
 version = "0.56.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -14331,7 +14334,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.54.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -14354,7 +14357,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.47.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -14377,7 +14380,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -14390,7 +14393,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.40.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "polkavm",
@@ -14401,7 +14404,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.43.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "anyhow",
  "log",
@@ -14417,7 +14420,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.54.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "console",
  "futures",
@@ -14433,7 +14436,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.5",
@@ -14447,7 +14450,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "arrayvec 0.7.6",
@@ -14475,7 +14478,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.55.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14524,7 +14527,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.52.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bitflags 1.3.2",
  "parity-scale-codec",
@@ -14534,7 +14537,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.55.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "ahash 0.8.12",
  "futures",
@@ -14553,7 +14556,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.54.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14574,7 +14577,7 @@ dependencies = [
 [[package]]
 name = "sc-network-statement"
 version = "0.37.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14595,7 +14598,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.54.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "async-channel 1.9.0",
@@ -14630,7 +14633,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.54.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "futures",
@@ -14649,7 +14652,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.20.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bs58",
  "bytes",
@@ -14670,7 +14673,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "50.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bytes",
  "fnv",
@@ -14704,7 +14707,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.20.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -14713,7 +14716,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "50.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -14745,7 +14748,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.54.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -14765,7 +14768,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "dyn-clone",
  "forwarded-header-value",
@@ -14789,7 +14792,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.55.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "futures",
@@ -14822,13 +14825,13 @@ dependencies = [
 [[package]]
 name = "sc-runtime-utilities"
 version = "0.7.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "sc-executor",
  "sc-executor-common",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-state-machine",
  "sp-wasm-interface",
  "thiserror 1.0.69",
@@ -14837,7 +14840,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.56.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "directories",
@@ -14901,7 +14904,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.41.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -14912,7 +14915,7 @@ dependencies = [
 [[package]]
 name = "sc-statement-store"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "parity-db",
@@ -14932,7 +14935,7 @@ dependencies = [
 [[package]]
 name = "sc-storage-monitor"
 version = "0.27.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "clap",
  "fs4",
@@ -14945,7 +14948,7 @@ dependencies = [
 [[package]]
 name = "sc-sync-state-rpc"
 version = "0.55.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -14964,7 +14967,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "46.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "derive_more 0.99.20",
  "futures",
@@ -14977,14 +14980,14 @@ dependencies = [
  "serde",
  "serde_json",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-io",
 ]
 
 [[package]]
 name = "sc-telemetry"
 version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "chrono",
  "futures",
@@ -15003,7 +15006,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "chrono",
  "console",
@@ -15031,7 +15034,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
@@ -15042,7 +15045,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "44.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -15059,7 +15062,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -15074,7 +15077,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -15092,7 +15095,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-channel 1.9.0",
  "futures",
@@ -15791,7 +15794,7 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 [[package]]
 name = "slot-range-helper"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -15949,8 +15952,8 @@ dependencies = [
 
 [[package]]
 name = "snowbridge-core"
-version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "0.18.1"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bp-relayers",
  "frame-support",
@@ -16027,7 +16030,7 @@ dependencies = [
 [[package]]
 name = "solochain-template-runtime"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-benchmarking",
  "frame-executive",
@@ -16068,7 +16071,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "hash-db",
@@ -16090,7 +16093,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -16104,7 +16107,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16116,7 +16119,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -16130,7 +16133,7 @@ dependencies = [
 [[package]]
 name = "sp-authority-discovery"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16142,7 +16145,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -16152,7 +16155,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -16171,7 +16174,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "futures",
@@ -16185,7 +16188,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16201,7 +16204,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16219,7 +16222,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-beefy"
 version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16227,7 +16230,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-io",
  "sp-keystore",
  "sp-mmr-primitives",
@@ -16239,7 +16242,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -16256,7 +16259,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-pow"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -16267,7 +16270,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.46.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16278,7 +16281,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "39.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "ark-vrf",
  "array-bytes",
@@ -16309,7 +16312,7 @@ dependencies = [
  "secrecy 0.8.0",
  "serde",
  "sha2 0.10.9",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-debug-derive",
  "sp-externalities",
  "sp-std",
@@ -16325,15 +16328,15 @@ dependencies = [
 [[package]]
 name = "sp-core-hashing"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
 ]
 
 [[package]]
 name = "sp-crypto-ec-utils"
 version = "0.19.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "ark-bls12-377 0.5.0",
  "ark-bls12-377-ext",
@@ -16367,7 +16370,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -16380,17 +16383,17 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "syn 2.0.114",
 ]
 
 [[package]]
 name = "sp-database"
 version = "10.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "kvdb",
  "kvdb-rocksdb",
@@ -16400,7 +16403,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -16410,7 +16413,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.31.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -16420,7 +16423,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.21.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16432,7 +16435,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -16445,7 +16448,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "44.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bytes",
  "docify",
@@ -16457,7 +16460,7 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -16471,7 +16474,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -16481,7 +16484,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.45.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.5",
@@ -16492,7 +16495,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "thiserror 1.0.69",
  "zstd 0.12.4",
@@ -16501,7 +16504,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.12.1"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -16511,7 +16514,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.18.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16522,7 +16525,7 @@ dependencies = [
 [[package]]
 name = "sp-mmr-primitives"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -16539,7 +16542,7 @@ dependencies = [
 [[package]]
 name = "sp-npos-elections"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16552,7 +16555,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -16562,7 +16565,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "backtrace",
  "regex",
@@ -16571,7 +16574,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "37.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "rustc-hash 1.1.0",
  "serde",
@@ -16581,7 +16584,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "45.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "binary-merkle-tree",
  "bytes",
@@ -16612,7 +16615,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "33.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -16630,7 +16633,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "Inflector",
  "expander",
@@ -16643,7 +16646,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -16657,7 +16660,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "42.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -16670,7 +16673,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.49.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "hash-db",
  "log",
@@ -16690,7 +16693,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -16703,7 +16706,7 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1)",
+ "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2)",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -16714,12 +16717,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 
 [[package]]
 name = "sp-storage"
 version = "22.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -16731,7 +16734,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16743,7 +16746,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "regex",
@@ -16755,7 +16758,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -16764,7 +16767,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "40.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -16777,8 +16780,8 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "42.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "42.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "ahash 0.8.12",
  "foldhash 0.1.5",
@@ -16803,7 +16806,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "43.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -16820,7 +16823,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "parity-scale-codec",
  "proc-macro-warning",
@@ -16832,7 +16835,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -16844,7 +16847,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "33.2.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "bounded-collections 0.3.2",
  "parity-scale-codec",
@@ -16910,7 +16913,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staging-chain-spec-builder"
 version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "clap",
  "docify",
@@ -16923,7 +16926,7 @@ dependencies = [
 [[package]]
 name = "staging-parachain-info"
 version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -16936,7 +16939,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm"
 version = "21.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "array-bytes",
  "bounded-collections 0.3.2",
@@ -16957,7 +16960,7 @@ dependencies = [
 [[package]]
 name = "staging-xcm-builder"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "environmental",
  "frame-support",
@@ -16980,8 +16983,8 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "24.0.1"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -17093,7 +17096,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -17118,12 +17121,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "49.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -17143,7 +17146,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.7"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "http-body-util",
  "hyper 1.8.1",
@@ -17157,7 +17160,7 @@ dependencies = [
 [[package]]
 name = "substrate-state-trie-migration-rpc"
 version = "48.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -17178,7 +17181,7 @@ version = "0.1.0"
 [[package]]
 name = "substrate-wasm-builder"
 version = "31.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "build-helper",
  "cargo_metadata",
@@ -17561,7 +17564,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 [[package]]
 name = "testnet-parachains-constants"
 version = "18.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -17972,7 +17975,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum"
 version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -17983,7 +17986,7 @@ dependencies = [
 [[package]]
 name = "tracing-gum-proc-macro"
 version = "5.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "expander",
  "proc-macro-crate 3.4.0",
@@ -18961,8 +18964,8 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "westend-runtime"
-version = "30.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+version = "30.2.0"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -19070,7 +19073,7 @@ dependencies = [
 [[package]]
 name = "westend-runtime-constants"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -19643,7 +19646,7 @@ dependencies = [
 [[package]]
 name = "xcm-procedural"
 version = "11.0.2"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -19654,7 +19657,7 @@ dependencies = [
 [[package]]
 name = "xcm-runtime-apis"
 version = "0.12.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -19668,7 +19671,7 @@ dependencies = [
 [[package]]
 name = "xcm-simulator"
 version = "25.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-1#c6ba84fb4938a367d0d0e06bb532b2cd8874fad9"
+source = "git+https://github.com/paritytech/polkadot-sdk.git?tag=polkadot-stable2512-2#00fbc91e415b563fd1b4f839628cdd392adcd0d4"
 dependencies = [
  "frame-support",
  "frame-system",

--- a/templates/Cargo.toml
+++ b/templates/Cargo.toml
@@ -14,48 +14,48 @@ members = [
 [workspace.dependencies]
 ziggy = {version = "1.3.1", default-features = false}
 
-solochain-template-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-kitchensink-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
+solochain-template-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+kitchensink-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
 
 codec = { version = "3.7.5", features = ["derive", "max-encoded-len"], default-features = false, package = "parity-scale-codec" }
 scale-info = { default-features = false, version = "2.11.6", features = ["std"] }
 frame-metadata = { default-features = false, version = "23.0.1", features = ["current", "decode", "std"] }
 
-node-primitives = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
+node-primitives = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
 
-frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
 
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-sp-consensus-babe = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-sp-consensus-beefy = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-sp-authority-discovery = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+sp-state-machine = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+sp-consensus-aura = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+sp-consensus-babe = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+sp-consensus-beefy = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+sp-authority-discovery = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
 
-pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-grandpa = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-staking = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-im-online = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-referenda = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-contracts = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-society = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-lottery = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-multisig = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-remark = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-transaction-storage = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-treasury = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-collective = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-proxy = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-broker = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-meta-tx = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-asset-rewards = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-whitelist = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-bags-list = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-recovery = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
-pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-1", default-features = false }
+pallet-timestamp = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-grandpa = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-staking = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-im-online = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-referenda = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-contracts = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-society = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-lottery = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-utility = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-multisig = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-remark = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-transaction-storage = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-sudo = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-treasury = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-collective = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-proxy = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-broker = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-meta-tx = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-asset-rewards = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-whitelist = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-bags-list = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-recovery = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }
+pallet-assets = { git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2512-2", default-features = false }

--- a/templates/kitchensink/src/main.rs
+++ b/templates/kitchensink/src/main.rs
@@ -233,7 +233,10 @@ fn recursively_find_call(call: RuntimeCall, matches_on: fn(&RuntimeCall) -> bool
     | RuntimeCall::Proxy(
         pallet_proxy::Call::proxy { call, .. } | pallet_proxy::Call::proxy_announced { call, .. },
     )
-    | RuntimeCall::Revive(pallet_revive::Call::dispatch_as_fallback_account { call }| pallet_revive::Call::eth_substrate_call {call,..})
+    | RuntimeCall::Revive(
+        pallet_revive::Call::dispatch_as_fallback_account { call }
+        | pallet_revive::Call::eth_substrate_call { call, .. },
+    )
     | RuntimeCall::Recovery(pallet_recovery::Call::as_recovered { call, .. })
     | RuntimeCall::Council(
         pallet_collective::Call::propose { proposal: call, .. }

--- a/templates/kitchensink/src/main.rs
+++ b/templates/kitchensink/src/main.rs
@@ -233,7 +233,7 @@ fn recursively_find_call(call: RuntimeCall, matches_on: fn(&RuntimeCall) -> bool
     | RuntimeCall::Proxy(
         pallet_proxy::Call::proxy { call, .. } | pallet_proxy::Call::proxy_announced { call, .. },
     )
-    | RuntimeCall::Revive(pallet_revive::Call::dispatch_as_fallback_account { call })
+    | RuntimeCall::Revive(pallet_revive::Call::dispatch_as_fallback_account { call }| pallet_revive::Call::eth_substrate_call {call,..})
     | RuntimeCall::Recovery(pallet_recovery::Call::as_recovered { call, .. })
     | RuntimeCall::Council(
         pallet_collective::Call::propose { proposal: call, .. }


### PR DESCRIPTION
Changed cargo.toml, cargo.lock for polkadot stable version 2512-2, added fixes for the recursive call filters.