### PR TITLE
Enable outbound XCM message for parachain fuzzers

### DIFF
--- a/runtimes/asset-hub-kusama/src/main.rs
+++ b/runtimes/asset-hub-kusama/src/main.rs
@@ -273,9 +273,10 @@ fn initialize_block(block: u32, prev_header: Option<&Header>) {
         //   1004  People     /  1005  Coretime
         let outbound_parachains: &[u32] = &[1001, 1002, 1004, 1005];
         for &para_id in outbound_parachains {
-            let ch = sproof_builder.upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
+            let ch = sproof_builder
+                .upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
             ch.max_capacity = 1024;
-            ch.max_total_size = 1 << 20;   // 1 MiB
+            ch.max_total_size = 1 << 20; // 1 MiB
             ch.max_message_size = 102_400; // 100 KiB, relay-chain default
         }
 

--- a/runtimes/asset-hub-kusama/src/main.rs
+++ b/runtimes/asset-hub-kusama/src/main.rs
@@ -262,12 +262,22 @@ fn initialize_block(block: u32, prev_header: Option<&Header>) {
         use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 
         let parent_head = HeadData(prev_header.unwrap_or(parent_header).encode());
-        let sproof_builder = RelayStateSproofBuilder {
+        let mut sproof_builder = RelayStateSproofBuilder {
             para_id: 100.into(),
             current_slot: cumulus_primitives_core::relay_chain::Slot::from(2 * u64::from(block)),
             included_para_head: Some(parent_head.clone()),
             ..Default::default()
         };
+        // Sibling system parachains AssetHub-Kusama may target via XCMP.
+        //   1001  Collectives  /  1002  BridgeHub
+        //   1004  People     /  1005  Coretime
+        let outbound_parachains: &[u32] = &[1001, 1002, 1004, 1005];
+        for &para_id in outbound_parachains {
+            let ch = sproof_builder.upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
+            ch.max_capacity = 1024;
+            ch.max_total_size = 1 << 20;   // 1 MiB
+            ch.max_message_size = 102_400; // 100 KiB, relay-chain default
+        }
 
         let relay_parent_offset = 1;
         let (relay_parent_storage_root, relay_chain_state, relay_parent_descendants) =

--- a/runtimes/asset-hub-polkadot/src/main.rs
+++ b/runtimes/asset-hub-polkadot/src/main.rs
@@ -288,12 +288,22 @@ fn initialize_block(block: u32, prev_header: Option<&Header>) {
         use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 
         let parent_head = HeadData(prev_header.unwrap_or(parent_header).encode());
-        let sproof_builder = RelayStateSproofBuilder {
+        let mut sproof_builder = RelayStateSproofBuilder {
             para_id: 100.into(),
             current_slot: cumulus_primitives_core::relay_chain::Slot::from(2 * u64::from(block)),
             included_para_head: Some(parent_head.clone()),
             ..Default::default()
         };
+        // Sibling system parachains AssetHub-Polkadot may target via XCMP.
+        //   1001  Collectives  /  1002  BridgeHub
+        //   1004  People       /  1005  Coretime  /  1010  Bulletin
+        let outbound_parachains: &[u32] = &[1001, 1002, 1004, 1005, 1010];
+        for &para_id in outbound_parachains {
+            let ch = sproof_builder.upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
+            ch.max_capacity = 1024;
+            ch.max_total_size = 1 << 20;   // 1 MiB
+            ch.max_message_size = 102_400; // 100 KiB, relay-chain default
+        }
 
         let relay_parent_offset = 1;
         let (relay_parent_storage_root, relay_chain_state, relay_parent_descendants) =

--- a/runtimes/asset-hub-polkadot/src/main.rs
+++ b/runtimes/asset-hub-polkadot/src/main.rs
@@ -299,9 +299,10 @@ fn initialize_block(block: u32, prev_header: Option<&Header>) {
         //   1004  People       /  1005  Coretime  /  1010  Bulletin
         let outbound_parachains: &[u32] = &[1001, 1002, 1004, 1005, 1010];
         for &para_id in outbound_parachains {
-            let ch = sproof_builder.upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
+            let ch = sproof_builder
+                .upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
             ch.max_capacity = 1024;
-            ch.max_total_size = 1 << 20;   // 1 MiB
+            ch.max_total_size = 1 << 20; // 1 MiB
             ch.max_message_size = 102_400; // 100 KiB, relay-chain default
         }
 

--- a/runtimes/coretime-kusama/src/main.rs
+++ b/runtimes/coretime-kusama/src/main.rs
@@ -248,9 +248,10 @@ fn initialize_block(block: u32, prev_header: Option<&Header>) {
         //   1002  BridgeHub  /  1004  People
         let outbound_parachains: &[u32] = &[1000, 1001, 1002, 1004];
         for &para_id in outbound_parachains {
-            let ch = sproof_builder.upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
+            let ch = sproof_builder
+                .upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
             ch.max_capacity = 1024;
-            ch.max_total_size = 1 << 20;   // 1 MiB
+            ch.max_total_size = 1 << 20; // 1 MiB
             ch.max_message_size = 102_400; // 100 KiB, relay-chain default
         }
 

--- a/runtimes/coretime-kusama/src/main.rs
+++ b/runtimes/coretime-kusama/src/main.rs
@@ -237,12 +237,22 @@ fn initialize_block(block: u32, prev_header: Option<&Header>) {
         use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 
         let parent_head = HeadData(prev_header.unwrap_or(&parent_header).encode());
-        let sproof_builder = RelayStateSproofBuilder {
+        let mut sproof_builder = RelayStateSproofBuilder {
             para_id: 100.into(),
             current_slot: Slot::from(2 * u64::from(block)),
             included_para_head: Some(parent_head.clone()),
             ..Default::default()
         };
+        // Sibling system parachains Coretime-Kusama may target via XCMP.
+        //   1000  AssetHub   /  1001  Collectives
+        //   1002  BridgeHub  /  1004  People
+        let outbound_parachains: &[u32] = &[1000, 1001, 1002, 1004];
+        for &para_id in outbound_parachains {
+            let ch = sproof_builder.upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
+            ch.max_capacity = 1024;
+            ch.max_total_size = 1 << 20;   // 1 MiB
+            ch.max_message_size = 102_400; // 100 KiB, relay-chain default
+        }
 
         let relay_parent_offset = 1;
         let (relay_parent_storage_root, relay_chain_state, relay_parent_descendants) =

--- a/runtimes/people-kusama/src/main.rs
+++ b/runtimes/people-kusama/src/main.rs
@@ -228,9 +228,10 @@ fn initialize_block(block: u32, prev_header: Option<&Header>) {
         //   1002  BridgeHub  /  1005  Coretime
         let outbound_parachains: &[u32] = &[1000, 1001, 1002, 1005];
         for &para_id in outbound_parachains {
-            let ch = sproof_builder.upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
+            let ch = sproof_builder
+                .upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
             ch.max_capacity = 1024;
-            ch.max_total_size = 1 << 20;   // 1 MiB
+            ch.max_total_size = 1 << 20; // 1 MiB
             ch.max_message_size = 102_400; // 100 KiB, relay-chain default
         }
 

--- a/runtimes/people-kusama/src/main.rs
+++ b/runtimes/people-kusama/src/main.rs
@@ -217,12 +217,22 @@ fn initialize_block(block: u32, prev_header: Option<&Header>) {
         use cumulus_test_relay_sproof_builder::RelayStateSproofBuilder;
 
         let parent_head = HeadData(prev_header.unwrap_or(parent_header).encode());
-        let sproof_builder = RelayStateSproofBuilder {
+        let mut sproof_builder = RelayStateSproofBuilder {
             para_id: 100.into(),
             current_slot: cumulus_primitives_core::relay_chain::Slot::from(2 * u64::from(block)),
             included_para_head: Some(parent_head.clone()),
             ..Default::default()
         };
+        // Sibling system parachains People-Kusama may target via XCMP.
+        //   1000  AssetHub   /  1001  Collectives
+        //   1002  BridgeHub  /  1005  Coretime
+        let outbound_parachains: &[u32] = &[1000, 1001, 1002, 1005];
+        for &para_id in outbound_parachains {
+            let ch = sproof_builder.upsert_outbound_channel(cumulus_primitives_core::ParaId::from(para_id));
+            ch.max_capacity = 1024;
+            ch.max_total_size = 1 << 20;   // 1 MiB
+            ch.max_message_size = 102_400; // 100 KiB, relay-chain default
+        }
 
         let relay_parent_offset = 1;
         let (relay_parent_storage_root, relay_chain_state, relay_parent_descendants) =


### PR DESCRIPTION
Enable XCM outbound channel to sibling system parachains for each parachain fuzzer